### PR TITLE
refactor: just send the song's ID to the background script

### DIFF
--- a/src/background_scripts/background_script.ts
+++ b/src/background_scripts/background_script.ts
@@ -1,16 +1,12 @@
 import browser, { tabs } from 'webextension-polyfill';
-import { InternalMessageCode } from '../extension_message';
-import { WebSocketManager } from '../web_socket_manager';
+import { InternalMessageCode, InternalMessageResponse } from '../extension_message';
 
 // Bind the button click to the function that will send the information through
 // the web socket.
 browser.browserAction.onClicked.addListener(extensionButtonClickListener);
 
+// Add a listener for the incoming messages coming from the content script.
 browser.runtime.onMessage.addListener(contentScriptResponseHandler);
-
-// Create the web socket manager which we will use to keep the web socket
-// connection up for sending the information over.
-const wsm = new WebSocketManager();
 
 /**
  * Sends the relevant information through the web socket.
@@ -20,7 +16,7 @@ function extensionButtonClickListener(): void {
         function (tabsResults: browser.Tabs.Tab[]){
             for (const tab of tabsResults) {
                 if (tab.id !== undefined) {
-                    tabs.sendMessage(tab.id, InternalMessageCode.GET_ALL);
+                    tabs.sendMessage(tab.id, InternalMessageCode.GET);
                 }
             }
         }
@@ -32,6 +28,6 @@ function extensionButtonClickListener(): void {
  * websocket.
  * @param response the sent response from the c ontent script.
  */
-function contentScriptResponseHandler(response: string): void {
-    wsm.sendMessage(response);
+function contentScriptResponseHandler(response: InternalMessageResponse): void {
+    console.log(response);
 }

--- a/src/content_scripts/content_script.ts
+++ b/src/content_scripts/content_script.ts
@@ -1,8 +1,11 @@
 import Browser from 'webextension-polyfill';
 import { InternalMessageCode, InternalMessageResponse } from '../extension_message';
+import { MusicExtractor } from '../music_extractor';
 
 // Set the message listener for the messages coming from the background script.
 Browser.runtime.onMessage.addListener(backgroundMessageListener);
+
+const musicExtractor = new MusicExtractor();
 
 /**
  * Listens to the background script's messages.
@@ -11,96 +14,25 @@ Browser.runtime.onMessage.addListener(backgroundMessageListener);
 function backgroundMessageListener(messageCode: string): void {
     const internalMessageCode:number = parseInt(messageCode);
 
-    if (internalMessageCode !== InternalMessageCode.GET_ALL) {
-        console.log('ERROR: unrecognizable internal message code received: ' + internalMessageCode);
-        return;
+    if (internalMessageCode !== InternalMessageCode.GET) {
+        throw new Error(`unrecognizable internal message code received: ${internalMessageCode}`);
     }
 
-    sendPlaylistAndPlayingTime();
+    sendSpotifyTrackUuid();
 }
 
 /**
  * Sends the current playlist from the page and the current playing time to the
  * background script.
  */
-function sendPlaylistAndPlayingTime(): void {
-    // Get the player iframe to be able to scrap elements from it, as the iframe
-    // eleements cannot be accessed through the "document" object directly.
-    const playerIframeElement = document.getElementById('smphtml5iframesmp-wrapper');
-
-    if (!(playerIframeElement instanceof HTMLIFrameElement)) {
-        console.log('ERROR: the fetched HTML element doesn\'t seem to be the player iframe: ' + playerIframeElement);
-        return;
-    }
-
-    // Grab the script tag that doesn't contain any attributes and contains the
-    // text "PRELOADED".
-    const iterator = document.evaluate(
-        '//script[not(@*) and text()[contains(.,"PRELOADED")]]',
-        document,
-        null,
-        XPathResult.UNORDERED_NODE_ITERATOR_TYPE, null
-    );
-
-
-    // There should only be one single script with the playlist information.
-    const scriptNode = iterator.iterateNext();
-    if (scriptNode === null || scriptNode.textContent === null) {
-        console.log('ERROR: either the script node or its contents are null');
-        return;
-    }
-
-    // Grab the RAW text content.
-    const scriptText = scriptNode.textContent;
-
-    // Try to simply grab the JSON object, because the script tag usually comes
-    // with more things we are not interested in.
-    const regexp = new RegExp('{.+}');
-    const match = regexp.exec(scriptText);
-
-    if (match === null) {
-        console.log('ERROR: unable to grab the JSON with the playlist information');
-        return;
-    }
-
-    if (match.length != 1) {
-        console.log('ERROR: more than one playlist JSON matched');
-        return;
-    }
-
-    // At this point, we've got the playlist info ready to be sent.
-    const playlistInfo = match[0];
-
-    // Try to get the player's iframe object.
-    let playerIframe = playerIframeElement.contentDocument;
-    if (playerIframe === null) {
-        if (playerIframeElement.contentWindow === null) {
-            console.log('ERROR: unable to acces the iframe contents as they seem to be empty');
-            return;
-        }
-
-        playerIframe = playerIframeElement.contentWindow.document;
-    }
-
-    // Try to grab the "current playing time" display element.
-    const timeDisplay = playerIframe.getElementById('p_audioui_leftTimeDisplay');
-    if (timeDisplay === null) {
-        console.log('ERROR: the time display element is null');
-        return;
-    }
-
-    const currentPlayingTime = timeDisplay.textContent;
-    if (currentPlayingTime === null || currentPlayingTime === '') {
-        console.log('ERROR: unable to ge the current playing time from the node since it is null or empty');
-        return;
-    }
+function sendSpotifyTrackUuid(): void {
+    musicExtractor.initialize();
 
     // Send the information to the background script.
     Browser.runtime.sendMessage(
         new InternalMessageResponse(
             InternalMessageCode.OK,
-            currentPlayingTime,
-            playlistInfo,
+            musicExtractor.getCurrentPlayingSongUuid()
         )
     );
 }

--- a/src/extension_message.ts
+++ b/src/extension_message.ts
@@ -1,6 +1,6 @@
 export enum InternalMessageCode {
     // Used for when the song list along with the time display are requested.
-    GET_ALL,
+    GET,
     // Used for when the message creation process didn't have any errors.
     OK,
 }
@@ -11,24 +11,18 @@ export enum InternalMessageCode {
  */
 export class InternalMessageResponse {
     private code: number;
-    private currentTime: string;
-    private playlistContents: string;
+    private spotifyTrackUuid: string;
 
-    constructor(code: number, currentTime: string, playlistContents: string) {
+    constructor(code: number, spotifyTrackUuid: string,) {
         this.code = code;
-        this.currentTime = currentTime;
-        this.playlistContents = playlistContents;
+        this.spotifyTrackUuid = spotifyTrackUuid;
     }
 
     public getCode(): number {
         return this.code;
     }
 
-    public getCurrentTime(): string {
-        return this.currentTime;
-    }
-
-    public getPlaylistContents(): string {
-        return this.playlistContents;
+    public getSpotifyTrackUuid(): string {
+        return this.spotifyTrackUuid;
     }
 }

--- a/src/music_extractor.ts
+++ b/src/music_extractor.ts
@@ -1,0 +1,136 @@
+import { Playlist, Track, Tracklist } from './playlist';
+import { SpotifyTrack } from './spotify_track';
+
+export class MusicExtractor {
+    // The time display property is definitely not null or undefined, since we
+    // check for that before assigning it.
+    private timeDisplay!: HTMLElement;
+    private readonly trackList: SpotifyTrack[] = [];
+
+    public initialize(): void {
+        if (this.timeDisplay != null || this.timeDisplay != undefined) {
+            return;
+        }
+
+        // Get the player iframe to be able to scrap elements from it, as the iframe
+        // eleements cannot be accessed through the "document" object directly.
+        const playerIframeElement = document.getElementById('smphtml5iframesmp-wrapper');
+
+        if (!(playerIframeElement instanceof HTMLIFrameElement)) {
+            console.log('ERROR: the fetched HTML element doesn\'t seem to be the player iframe: ' + playerIframeElement);
+            return;
+        }
+
+        // Grab the script tag that doesn't contain any attributes and contains the
+        // text "PRELOADED".
+        const iterator = document.evaluate(
+            '//script[not(@*) and text()[contains(.,"PRELOADED")]]',
+            document,
+            null,
+            XPathResult.UNORDERED_NODE_ITERATOR_TYPE, null
+        );
+
+        // There should only be one single script with the playlist information.
+        const scriptNode = iterator.iterateNext();
+        if (scriptNode === null || scriptNode.textContent === null) {
+            throw new Error('unable to locate the script node containing the playlist');
+        }
+
+        // Grab the RAW text content.
+        const scriptText = scriptNode.textContent;
+
+        // Try to simply grab the JSON object, because the script tag usually comes
+        // with more things we are not interested in.
+        const regexp = new RegExp('{.+}');
+        const match = regexp.exec(scriptText);
+
+        if (match === null) {
+            throw new Error('unable to locate the JSON with the playlist\'s information');
+        }
+
+        if (match.length != 1) {
+            throw new Error('more than one playlist was located in the page');
+        }
+
+        // At this point, we've got the playlist information.
+        const playlistInfo: Playlist = JSON.parse(match[0]);
+        const trackListObject: Tracklist = playlistInfo.tracklist;
+        const tracks: Track[] = trackListObject.tracks;
+        tracks.forEach(track => {
+            this.trackList.push(new SpotifyTrack(track));
+        });
+
+        // Try to get the player's iframe object.
+        let playerIframe = playerIframeElement.contentDocument;
+        if (playerIframe === null) {
+            if (playerIframeElement.contentWindow === null) {
+                throw new Error('ERROR: unable to acces the iframe contents as they seem to be empty');
+            }
+
+            playerIframe = playerIframeElement.contentWindow.document;
+        }
+
+        // Try to grab the "current playing time" display element.
+        const timeDisplay = playerIframe.getElementById('p_audioui_leftTimeDisplay');
+        if (timeDisplay === null || timeDisplay === undefined) {
+            throw new Error('unable to locate the track\'s time display element in the page');
+        }
+
+        this.timeDisplay = timeDisplay;
+    }
+
+    /**
+     * Gets the song's UUID from the current playing track.
+     */
+    public getCurrentPlayingSongUuid(): string {
+        const currentPlayingTime = this.getCurrentPlayingTime();
+
+        let startOffsetTooBigCount = 0;
+        for (const track of this.trackList) {
+            if (startOffsetTooBigCount > 2) {
+                break;
+            }
+
+            if (track.isOffsetLowerThanTracksStartOffset(currentPlayingTime)) {
+                startOffsetTooBigCount++;
+            }
+
+            if (track.isSongBeingPlayedRightNow(currentPlayingTime)) {
+                return track.getTrackUuid();
+            }
+        }
+
+        throw new Error('unable to find the current playing track');
+    }
+
+    /**
+     * Gets the current playing time from the music player.
+     * @returns the offset of the current playing time.
+     */
+    private getCurrentPlayingTime(): number {
+        const currentPlayingTime = this.timeDisplay.textContent;
+        if (currentPlayingTime === null || currentPlayingTime === '') {
+            throw new Error('ERROR: unable to get the current playing time from the node since it is null or empty');
+        }
+
+        const time: string[] = currentPlayingTime.split(':');
+
+        let hours: number;
+        let minutes: number;
+        let seconds: number;
+
+        if (time.length === 2) {
+            hours = 0;
+            minutes = parseInt(time[0]);
+            seconds = parseInt(time[1]);
+        } else if (time.length === 3) {
+            hours = parseInt(time[0]);
+            minutes = parseInt(time[1]);
+            seconds = parseInt(time[2]);
+        } else {
+            throw new Error(`the current playing time is in an unexpected format: ${currentPlayingTime}`);
+        }
+
+        return (hours * 3600) + (minutes * 60) + seconds;
+    }
+}

--- a/src/playlist.ts
+++ b/src/playlist.ts
@@ -1,0 +1,22 @@
+export interface Playlist {
+    tracklist: Tracklist
+}
+
+export interface Tracklist {
+    tracks: Track[]
+}
+
+export interface Track {
+    offset: Offset,
+    uris: URI[]
+}
+
+export interface Offset {
+    start: number,
+    end: number
+}
+
+export interface URI {
+    id: string,
+    uri: string
+}

--- a/src/spotify_track.ts
+++ b/src/spotify_track.ts
@@ -1,0 +1,49 @@
+import { Track } from './playlist';
+
+export class SpotifyTrack {
+    private readonly startOffset: number;
+    private readonly endOffset: number;
+    private trackUuid!: string;
+
+    constructor(rawTrack: Track) {
+        this.startOffset = rawTrack.offset.start;
+        this.endOffset = rawTrack.offset.end;
+
+        const uris = rawTrack.uris;
+        uris.forEach(uri => {
+            if (uri.uri.indexOf('spotify') >= 0 || uri.uri.indexOf('Spotify') >= 0) {
+                const regexp = new RegExp('[^/]+$');
+                const match = regexp.exec(uri.uri);
+                if (match == null) {
+                    console.log(`unable to grab the Spotify ID from the URL ${uri}`);
+                    return;
+                }
+
+                if (match.length != 1) {
+                    console.log(`more than one ID found in URI ${uri}`);
+                    return;
+                }
+
+                this.trackUuid = match[0];
+            }
+        });
+    }
+
+    /**
+     * Checks if the given offset is lower than the start offset of this track.
+     * @param offset the offset to check against.
+     * @returns true if the given offset is lower than the start offset of this
+     * track.
+     */
+    public isOffsetLowerThanTracksStartOffset(offset: number): boolean {
+        return offset <= this.startOffset;
+    }
+
+    public isSongBeingPlayedRightNow(currentPlayingTime: number): boolean {
+        return currentPlayingTime >= this.startOffset && currentPlayingTime <= this.endOffset;
+    }
+
+    public getTrackUuid(): string {
+        return this.trackUuid;
+    }
+}


### PR DESCRIPTION
Since the Rust backend has been discarded for now, and since everything is going to be self contained in the extension, the structure of how things are done has changed a bit.

Now the content script is responsible for extracting the current playing song's ID, and sending it to the background script, which will take care of "liking" it in Spotify.