### PR TITLE
refactor: decouple the auth manager from the interactive area

### DIFF
--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -1,15 +1,38 @@
-import { AuthorizationManager } from './authorization_manager';
+import { AuthorizationManager } from '../authorization_manager';
 import { InteractiveArea } from './interactive_area';
 
 const interactiveArea = new InteractiveArea();
-const authManager = new AuthorizationManager(interactiveArea);
+const authManager = new AuthorizationManager();
+
+if (authManager.isAuthorized()) {
+    interactiveArea.hideConnectButton();
+    interactiveArea.displayLogoutButton();
+} else {
+    interactiveArea.displayConnectButton();
+    interactiveArea.hideLogoutButton();
+}
 
 const connectButton = interactiveArea.getConnectButton();
 
 // Use a function with the "authManager" to make sure that "this" doesn't point
 // to the button instead of the class.
-connectButton.addEventListener('click', function() { authManager.authorize(); });
+connectButton.addEventListener('click', function() {
+    try {
+        authManager.authorize();
+
+        interactiveArea.clearErrorMessage();
+        interactiveArea.hideConnectButton();
+        interactiveArea.displayLogoutButton();
+    } catch (e: any) {
+        interactiveArea.postErrorMessage(e);
+    }
+});
 
 // We do the same thing with the logout button.
 const logoutButton = interactiveArea.getLogoutButton();
-logoutButton.addEventListener('click', function() { authManager.logout(); });
+logoutButton.addEventListener('click', function() {
+    authManager.logout();
+
+    interactiveArea.hideLogoutButton();
+    interactiveArea.displayConnectButton();
+});


### PR DESCRIPTION
It isn't the authorization manager's responsability to play with modifying the interactive elements. This should be done out of it so that the authorization manager can be used in other contexts where the specific UI from the options menu is not present.